### PR TITLE
Fix issue with application key missing during testing

### DIFF
--- a/.github/workflows/dependabot-composer.yml
+++ b/.github/workflows/dependabot-composer.yml
@@ -33,7 +33,7 @@ jobs:
         run: composer audit
 
       - name: Install dependencies
-        run: composer install --no-progress --no-suggest
+        run: composer create-project
 
       - name: Test
         run: php artisan test --parallel


### PR DESCRIPTION
### What's being changed

The application key is missing during testing because the composer project scripts aren't setting up the key. This change fixes that issue.