### PR TITLE
Use squash merge to preserve linear history

### DIFF
--- a/.github/workflows/dependabot-composer.yml
+++ b/.github/workflows/dependabot-composer.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-npm.yml
+++ b/.github/workflows/dependabot-npm.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### What's being changed

I am changing the dependabot auto-merge workflows to use squash commits so the repository's linear history is preserved.
