### PR TITLE
Install exact NPM dependencies

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,10 +57,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
-      - name: Install PHP dependencies
+      - name: Install PHP dependencies and build the project
         run: composer create-project
       - name: Install Node dependencies
-        run: npm install
+        run: npm ci
       - name: Build assets
         run: npm run build
 


### PR DESCRIPTION
### What's being changed

I am changing the CI install step for NPM packages so it installs the exact versions found in package-lock.json.